### PR TITLE
Add a Pattern type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,8 @@ version = "0.1.0"
 julia = "1"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Documenter", "Test"]

--- a/src/AxisSets.jl
+++ b/src/AxisSets.jl
@@ -1,5 +1,5 @@
 module AxisSets
 
-# Write your package code here.
+include("patterns.jl")
 
 end

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -37,7 +37,7 @@ struct Pattern
     segments::Tuple{Vararg{Symbol}}
 
     # We reduce the segments on construction to remove extra wildcards
-    # (e.g., `(:_, :__, ...)`, `(:__, :_, ...`)
+    # e.g., `(:_, :__, ...)` reduces to`(:__, ...`)
     # NOTE: Since these patterns shouldn't be very long it seemed alright to do in an
     # inner constructor
     function Pattern(segments::Tuple{Vararg{Symbol}})

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -2,8 +2,8 @@
 """
     Pattern
 
-A pattern is just a wrapper around a `Tuple{Vararg{Symbol}}` which enables searching for
-matching components and dimension paths in a Dataset.
+A pattern is just a wrapper around a `Tuple{Vararg{Symbol}}` which enables searching and
+filtering for matching components and dimension paths in a [`Dataset`](@ref).
 Special symbols `:_` and `:__` are used as wildcards, similar to `*` and `**` in glob
 pattern matching.
 """

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -44,15 +44,20 @@ struct Pattern
         n = length(segments)
         mask = trues(n)
 
-        prev = nothing
+        # Prev index used for lookup up segment and mask values as we iterate through
+        j = 1
 
         # Iterating forwards and backwards seemed like the easiest way to
         # remove extra wildcards on either side of a `:__`
-        for i in Iterators.flatten([1:n, n:-1:1])
-            if segments[i] === :_ && prev === :__
+        for i in Iterators.flatten([2:n, n-1:-1:1])
+            val = segments[i]
+            prev = segments[j]
+            prev_mask = mask[j]
+
+            if val in (:_, :__) && prev === :__ && prev_mask
                 mask[i] = false
             else
-                prev = segments[i]
+                j = i
             end
         end
 

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -6,6 +6,33 @@ A pattern is just a wrapper around a `Tuple{Vararg{Symbol}}` which enables searc
 filtering for matching components and dimension paths in a [`Dataset`](@ref).
 Special symbols `:_` and `:__` are used as wildcards, similar to `*` and `**` in glob
 pattern matching.
+
+# Example
+```jldoctest
+julia> using AxisSets: Pattern;
+
+julia> items = [
+           (:train, :input, :load, :time),
+           (:train, :input, :load, :id),
+           (:train, :input, :temperature, :time),
+           (:train, :input, :temperature, :id),
+           (:train, :output, :load, :time),
+           (:train, :output, :load, :id),
+       ];
+
+julia> filter(in(Pattern(:__, :time)), items)
+3-element Array{NTuple{4,Symbol},1}:
+ (:train, :input, :load, :time)
+ (:train, :input, :temperature, :time)
+ (:train, :output, :load, :time)
+
+julia> filter(in(Pattern(:__, :load, :_)), items)
+4-element Array{NTuple{4,Symbol},1}:
+ (:train, :input, :load, :time)
+ (:train, :input, :load, :id)
+ (:train, :output, :load, :time)
+ (:train, :output, :load, :id)
+```
 """
 struct Pattern
     segments::Tuple{Vararg{Symbol}}

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -50,14 +50,17 @@ struct Pattern
         # Iterating forwards and backwards seemed like the easiest way to
         # remove extra wildcards on either side of a `:__`
         for i in Iterators.flatten([2:n, n-1:-1:1])
-            val = segments[i]
+            curr = segments[i]
+            curr_mask = mask[i]
             prev = segments[j]
             prev_mask = mask[j]
 
-            if val in (:_, :__) && prev === :__ && prev_mask
-                mask[i] = false
-            else
-                j = i
+            if curr_mask
+                if curr === :__ && prev in (:_, :__) && prev_mask
+                    mask[j] = false
+                else
+                    j = i
+                end
             end
         end
 

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -1,0 +1,63 @@
+
+"""
+    Pattern
+
+A pattern is just a wrapper around a `Tuple{Vararg{Symbol}}` which enables searching for
+matching components and dimension paths in a Dataset.
+Special symbols `:_` and `:__` are used as wildcards, similar to `*` and `**` in glob
+pattern matching.
+"""
+struct Pattern
+    segments::Tuple{Vararg{Symbol}}
+end
+
+Pattern(segments::Symbol...) = Pattern(segments)
+Base.convert(::Type{Pattern}, x::Tuple{Vararg{Symbol}}) = Pattern(x)
+
+# Primary functionality is to support identify tuples that match the constraint
+# NOTE: I'm not entirely sure if we should overload `in` for this algorithm
+function Base.in(item::Tuple{Vararg{Symbol}}, pattern::Pattern)
+    pat = pattern.segments
+    i = 1   # item  index
+    j = 1   # contraint index
+    n = length(item)
+    m = length(pat)
+
+    # If our constrain has more segments than the item then it isn't going to match
+    m <= n || return false
+
+    result = true
+    while result && i <= n && j <= m
+        if pat[j] === item[i] || pat[j] === :_
+            i += 1
+            j += 1
+        elseif pat[j] === :__
+            # Lookahead if we aren't at the end
+            if j < m
+                _next = pat[j+1]
+
+                # If the next value matches the current item then just jump to the indices after both
+                if _next === item[i]
+                    i += 1
+                    j += 2
+                # Error if have multiple multiple wildcards in a row
+                elseif _next === :__ || _next === :_
+                    throw(ArgumentError("Cannot have multiple :_ or :__ wildcards in a row"))
+                # Otherwise we just bump the item index
+                else
+                    i += 1
+                end
+            else
+                # If our constraint ends with :__ then we automatically match the rest and
+                # we can bump the index
+                j += 1
+                i = n + 1
+            end
+        else
+            # If our segments don't match and aren't wildcards then it doesn't match
+            result = false
+        end
+    end
+
+    return result && i > n && j > m
+end

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -20,8 +20,8 @@
         (:predict, :output, :prices, :id),
     ]
 
-    @testset "Pattern(:__, :time)" begin
-        pattern = Pattern(:__, :time)
+    @testset "Pattern(:_, :_, :_, :time)" begin
+        pattern = Pattern(:_, :_, :_, :time)
         @test filter(in(pattern), items) == [
             (:train, :input, :prices, :time),
             (:train, :input, :load, :time),
@@ -34,8 +34,8 @@
         ]
     end
 
-    @testset "Pattern(:_, :_, :_, :time)" begin
-        pattern = Pattern(:_, :_, :_, :time)
+    @testset "Pattern(:__, :time)" begin
+        pattern = Pattern(:__, :time)
         @test filter(in(pattern), items) == [
             (:train, :input, :prices, :time),
             (:train, :input, :load, :time),
@@ -62,21 +62,6 @@
         ]
     end
 
-    @testset "Pattern(:__, :_, :time)" begin
-        # Check that our Pattern is reduced in cases where we have extra wildcards.
-        @test Pattern(:__, :_, :time) == Pattern(:__, :time)
-    end
-
-    @testset "Pattern(:_, :__, :time)" begin
-        # Check that our Pattern is reduced in cases where we have extra wildcards.
-        @test Pattern(:_, :__, :time) == Pattern(:__, :time)
-    end
-
-    @testset "Pattern(:__, :__, :time)" begin
-        # Check that our Pattern is reduced in cases where we have extra wildcards.
-        @test Pattern(:__, :__, :time) == Pattern(:__, :time)
-    end
-
     @testset "Pattern(:train, :input, :__)" begin
         pattern = Pattern(:train, :input, :__)
         @test filter(in(pattern), items) == [
@@ -88,5 +73,50 @@
             (:train, :input, :temperature, :time),
             (:train, :input, :temperature, :id),
         ]
+    end
+
+    @testset "Reductions" begin
+        @testset "Pattern(:__, :time)" begin
+            reduced = Pattern(:__, :time)
+
+            patterns = Pattern[
+                (:__, :_, :time),
+                (:_, :__, :time),
+                (:__, :__, :time),
+                (:_, :__, :_, :time),
+            ]
+            @testset "$p" for p in patterns
+                @test p == reduced
+            end
+
+            @test Pattern(:_, :_, :time) != reduced
+            @test Pattern(:_, :__, :time, :_) != reduced
+            @test Pattern(:time, :_, :__) != reduced
+        end
+
+        @testset "Pattern(:train, :__)" begin
+            reduced = Pattern(:train, :__)
+
+            patterns = Pattern[
+                (:train, :_, :__),
+                (:train, :__, :_),
+                (:train, :__, :__),
+                (:train, :_, :__, :_),
+            ]
+            @testset "$p" for p in patterns
+                @test p == reduced
+            end
+
+            @test Pattern(:train, :_, :_) != reduced
+            @test Pattern(:_, :train, :__, :_) != reduced
+            @test Pattern(:__, :_, :train) != reduced
+        end
+
+        @testset "Pattern(:_, :input, :__)" begin
+            reduced = Pattern(:_, :input, :__)
+
+            @test Pattern(:_, :input, :_, :__) == reduced
+            @test Pattern(:_, :__, :input, :__) != reduced
+        end
     end
 end

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -72,6 +72,11 @@
         @test Pattern(:_, :__, :time) == Pattern(:__, :time)
     end
 
+    @testset "Pattern(:__, :__, :time)" begin
+        # Check that our Pattern is reduced in cases where we have extra wildcards.
+        @test Pattern(:__, :__, :time) == Pattern(:__, :time)
+    end
+
     @testset "Pattern(:train, :input, :__)" begin
         pattern = Pattern(:train, :input, :__)
         @test filter(in(pattern), items) == [

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -63,8 +63,13 @@
     end
 
     @testset "Pattern(:__, :_, :time)" begin
-        pattern = Pattern(:__, :_, :time)
-        @test_throws ArgumentError filter(in(pattern), items)
+        # Check that our Pattern is reduced in cases where we have extra wildcards.
+        @test Pattern(:__, :_, :time) == Pattern(:__, :time)
+    end
+
+    @testset "Pattern(:_, :__, :time)" begin
+        # Check that our Pattern is reduced in cases where we have extra wildcards.
+        @test Pattern(:_, :__, :time) == Pattern(:__, :time)
     end
 
     @testset "Pattern(:train, :input, :__)" begin

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -1,0 +1,82 @@
+@testset "Patterns" begin
+    items = [
+        (:train, :input, :prices, :time),
+        (:train, :input, :prices, :id),
+        (:train, :input, :prices, :lag),
+        (:train, :input, :load, :time),
+        (:train, :input, :load, :id),
+        (:train, :input, :temperature, :time),
+        (:train, :input, :temperature, :id),
+        (:train, :output, :prices, :time),
+        (:train, :output, :prices, :id),
+        (:predict, :input, :prices, :time),
+        (:predict, :input, :prices, :id),
+        (:predict, :input, :prices, :lag),
+        (:predict, :input, :load, :time),
+        (:predict, :input, :load, :id),
+        (:predict, :input, :temperature, :time),
+        (:predict, :input, :temperature, :id),
+        (:predict, :output, :prices, :time),
+        (:predict, :output, :prices, :id),
+    ]
+
+    @testset "Pattern(:__, :time)" begin
+        pattern = Pattern(:__, :time)
+        @test filter(in(pattern), items) == [
+            (:train, :input, :prices, :time),
+            (:train, :input, :load, :time),
+            (:train, :input, :temperature, :time),
+            (:train, :output, :prices, :time),
+            (:predict, :input, :prices, :time),
+            (:predict, :input, :load, :time),
+            (:predict, :input, :temperature, :time),
+            (:predict, :output, :prices, :time),
+        ]
+    end
+
+    @testset "Pattern(:_, :_, :_, :time)" begin
+        pattern = Pattern(:_, :_, :_, :time)
+        @test filter(in(pattern), items) == [
+            (:train, :input, :prices, :time),
+            (:train, :input, :load, :time),
+            (:train, :input, :temperature, :time),
+            (:train, :output, :prices, :time),
+            (:predict, :input, :prices, :time),
+            (:predict, :input, :load, :time),
+            (:predict, :input, :temperature, :time),
+            (:predict, :output, :prices, :time),
+        ]
+    end
+
+    @testset "Pattern(:_, :time)" begin
+        pattern = Pattern(:_, :time)
+        @test isempty(filter(in(pattern), items))
+    end
+
+    @testset "Pattern(:train, :input, :_, :time)" begin
+        pattern = Pattern(:train, :input, :_, :time)
+        @test filter(in(pattern), items) == [
+            (:train, :input, :prices, :time),
+            (:train, :input, :load, :time),
+            (:train, :input, :temperature, :time),
+        ]
+    end
+
+    @testset "Pattern(:__, :_, :time)" begin
+        pattern = Pattern(:__, :_, :time)
+        @test_throws ArgumentError filter(in(pattern), items)
+    end
+
+    @testset "Pattern(:train, :input, :__)" begin
+        pattern = Pattern(:train, :input, :__)
+        @test filter(in(pattern), items) == [
+            (:train, :input, :prices, :time),
+            (:train, :input, :prices, :id),
+            (:train, :input, :prices, :lag),
+            (:train, :input, :load, :time),
+            (:train, :input, :load, :id),
+            (:train, :input, :temperature, :time),
+            (:train, :input, :temperature, :id),
+        ]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
 using AxisSets
+using Documenter
 using Test
 
 using AxisSets: Pattern
 
 @testset "AxisSets.jl" begin
     include("patterns.jl")
+    doctest(AxisSets)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using AxisSets
 using Test
 
+using AxisSets: Pattern
+
 @testset "AxisSets.jl" begin
-    # Write your tests here.
+    include("patterns.jl")
 end


### PR DESCRIPTION
This will be used to represent aligned/associated dimension path constraints.

NOTE: This syntax is very similar to filepath globbing. Since we don't want to conflate filepaths with dimpaths I've chosen to use `:_` as our wildcard character, which happens to match NamedDims.jl :) https://github.com/invenia/NamedDims.jl#partially-named-dimensions-_