### PR TITLE
Relax key and pattern tuple type constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -105,7 +105,7 @@ julia> ds2 = KeyedDataset(
        );
 
 julia> collect(keys(merge(ds1, ds2).data))
-4-element Array{Tuple{Vararg{Symbol,N} where N},1}:
+4-element Array{Tuple{Symbol},1}:
  (:a,)
  (:b,)
  (:c,)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -15,7 +15,7 @@ julia> ds = KeyedDataset(
        );
 
 julia> collect(keys(ds.data))
-2-element Array{Tuple{Vararg{Symbol,N} where N},1}:
+2-element Array{Tuple{Symbol},1}:
  (:val1,)
  (:val2,)
 
@@ -105,9 +105,9 @@ julia> ds = KeyedDataset(:a => KeyedArray(zeros(3); time=1:3));
 julia> ds[:b] = KeyedArray(ones(3, 2); time=1:3, lag=[-1, -2]);
 
 julia> collect(constraintmap(ds))
-2-element Array{Pair{AxisSets.Pattern,Set{Tuple{Vararg{Symbol,N} where N}}},1}:
- AxisSets.Pattern((:__, :time)) => Set([(:b, :time), (:a, :time)])
-  AxisSets.Pattern((:__, :lag)) => Set([(:b, :lag)])
+2-element Array{Pair{AxisSets.Pattern,Set{Tuple}},1}:
+ Pattern((:__, :time)) => Set([(:b, :time), (:a, :time)])
+  Pattern((:__, :lag)) => Set([(:b, :lag)])
 
 julia> ds[:c] = KeyedArray(ones(3, 2); time=2:4, lag=[-1, -2])
 ERROR: ArgumentError: Shared dimensions don't have matching keys
@@ -154,12 +154,12 @@ julia> ds = KeyedDataset(
        );
 
 julia> collect(keys(ds(:__, :a).data))
-2-element Array{Tuple{Vararg{Symbol,N} where N},1}:
+2-element Array{Tuple{Symbol,Symbol},1}:
  (:g1, :a)
  (:g2, :a)
 
 julia> collect(keys(ds(:g1, :__).data))
-2-element Array{Tuple{Vararg{Symbol,N} where N},1}:
+2-element Array{Tuple{Symbol,Symbol},1}:
  (:g1, :a)
  (:g1, :b)
 ```

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -190,6 +190,48 @@
                     Pattern((:__, :label)) => Set([(:group1_b, :label), (:group2_b, :label)]),
                 )
             end
+
+            @testset "Mixed key types" begin
+                # In this case, we have the option to having tuple keys which allows for
+                # multi-dimensional style indexing.
+                data = [
+                    :group1 => [
+                        "a" => KeyedArray(
+                            rand(4, 3, 2);
+                            time=DateTime(2021, 1, 1, 11):Hour(1):DateTime(2021, 1, 1, 14),
+                            loc=1:3,
+                            obj=[:a, :b],
+                        ),
+                        "b" => KeyedArray(
+                            rand(4, 2);
+                            time=DateTime(2021, 1, 1, 11):Hour(1):DateTime(2021, 1, 1, 14),
+                            label=["x", "y"],
+                        )
+                    ],
+                    :group2 => [
+                        "a" => KeyedArray(
+                            rand(4, 3, 2) .+ 1.0;
+                            time=DateTime(2021, 1, 1, 11):Hour(1):DateTime(2021, 1, 1, 14),
+                            loc=1:3,
+                            obj=[:a, :b],
+                        ),
+                        "b" => KeyedArray(
+                            rand(4, 2) .+ 1.0;
+                            time=DateTime(2021, 1, 1, 11):Hour(1):DateTime(2021, 1, 1, 14),
+                            label=["x", "y"],
+                        )
+                    ]
+                ]
+                ds = KeyedDataset(flatten(data)...)
+
+                # Test that we successfully extracted the dims
+                @test issetequal([:time, :loc, :obj, :label], dimnames(ds))
+
+                # Test that we successfully extracted the flattened pairs as tuples.
+                @test issetequal(
+                    [(:group1, "a"), (:group1, "b"), (:group2, "a"), (:group2, "b")], keys(ds.data)
+                )
+            end
         end
     end
     @testset "show" begin

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -209,7 +209,9 @@
         )
 
         # This is likely to change in the future, so we keep this test simple
-        @test startswith(sprint(show, ds), "$(typeof(ds)) with 2 entries:")
+        s = sprint(show, ds)
+        @test startswith(s, "KeyedDataset{Tuple{Symbol},")
+        @test occursin("with 2 entries", s)
     end
 
     @testset "dimpaths" begin

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -119,4 +119,40 @@
             @test Pattern(:_, :__, :input, :__) != reduced
         end
     end
+
+    @testset "Mixed types" begin
+        t1 = today()
+        t2 = t1 + Day(1)
+        items = [
+            (t1, 1, "prices", :time),
+            (t1, 1, "prices", :id),
+            (t1, 1, "prices", :lag),
+            (t1, 1, "load", :time),
+            (t1, 1, "load", :id),
+            (t1, 1, "temperature", :time),
+            (t1, 1, "temperature", :id),
+            (t1, 2, "prices", :time),
+            (t1, 2, "prices", :id),
+            (t2, 1, "prices", :time),
+            (t2, 1, "prices", :id),
+            (t2, 1, "prices", :lag),
+            (t2, 1, "load", :time),
+            (t2, 1, "load", :id),
+            (t2, 1, "temperature", :time),
+            (t2, 1, "temperature", :id),
+            (t2, 2, "prices", :time),
+            (t2, 2, "prices", :id),
+        ]
+
+        pattern = Pattern(t1, 1, :__)
+        @test filter(in(pattern), items) == [
+            (t1, 1, "prices", :time),
+            (t1, 1, "prices", :id),
+            (t1, 1, "prices", :lag),
+            (t1, 1, "load", :time),
+            (t1, 1, "load", :id),
+            (t1, 1, "temperature", :time),
+            (t1, 1, "temperature", :id),
+        ]
+    end
 end


### PR DESCRIPTION
Closes #31 

Technically, the type parameterization and `show` behaviour has changed slightly, so I’m not sure if this should be a patch or minor release.