### PR TITLE
Reduce show output and map dimensions to constraints.

### DIFF
--- a/src/AxisSets.jl
+++ b/src/AxisSets.jl
@@ -70,6 +70,21 @@ const DEFAULT_PROD_DELIM = :ᵡ
 # Short hand type for complicated union of nested Keyed or NamedDims arrays
 const XArray{L, T, N} = Union{NamedDimsArray{L,T,N,<:KeyedArray}, KeyedArray{T,N,<:NamedDimsArray}}
 
+# There's a few places calling `only` is convenient, even for older Julia releases
+if VERSION < v"1.4"
+    function _only(x)
+        if isempty(x)
+            throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
+        elseif length(x) > 1
+            throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
+        else
+            first(x)
+        end
+    end
+else
+    _only(x) = only(x)
+end
+
 include("flatten.jl")
 include("patterns.jl")
 include("dataset.jl")

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -69,11 +69,7 @@ function Base.show(io::IO, ds::KeyedDataset{K, T}) where {K, T}
         # Identify shared dimensions where appropriate
         dimensions = map(dimnames(v)) do dimname
             cidx = findall(c -> (k..., dimname) in c, constraints)
-            if isempty(cidx)
-                return dimname
-            else
-                return string(dimname, "[", only(cidx), "]")
-            end
+            isempty(cidx) ? string(dimname) : string(dimname, "[", _only(cidx), "]")
         end
 
         s = string(
@@ -90,11 +86,12 @@ function Base.show(io::IO, ds::KeyedDataset{K, T}) where {K, T}
     push!(lines, "  $m constraints")
 
     for (i, c) in enumerate(constraints)
-        push!(lines, "    [$i] $(c.segments) ∈ $(sprint(summary, only(axiskeys(ds, c))))")
+        push!(lines, "    [$i] $(c.segments) ∈ $(sprint(summary, _only(axiskeys(ds, c))))")
     end
 
     print(io, join(lines, "\n"))
 end
+
 
 """
     dimpaths(ds, [pattern]) -> Vector{<:Tuple}

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -59,15 +59,41 @@ KeyedDataset(; constraints=Pattern[], kwargs...) = KeyedDataset(kwargs...; const
 
 function Base.show(io::IO, ds::KeyedDataset{K, T}) where {K, T}
     n = length(ds.data)
-    print(io, "KeyedDataset{$K, $T} with $n entries:")
-    for c in ds.constraints
-        print(io, "\n  ", c)
-    end
+    m = length(ds.constraints)
+
+    # Extract the constraints as a vector for indexing
+    constraints = collect(ds.constraints)
+
+    lines = String["KeyedDataset with:", "  $n components"]
     for (k, v) in ds.data
-        printstyled(io, "\n  ", k, " => "; color=:cyan)
-        printstyled(io, replace(sprint(Base.summary, v), "\n" => "\n    "); color=:cyan)
-        print(io, "\n    ", replace(sprint(Base.print_array, v), "\n" => "\n    "))
+        # Identify shared dimensions where appropriate
+        dimensions = map(dimnames(v)) do dimname
+            cidx = findall(c -> (k..., dimname) in c, constraints)
+            if isempty(cidx)
+                return dimname
+            else
+                return string(dimname, "[", only(cidx), "]")
+            end
+        end
+
+        s = string(
+            "    $k => ",
+            join(size(v), "x"),
+            " $(nameof(typeof(v))){$(eltype(v))}",
+            " with dimension ",
+            join(dimensions, ", ")
+        )
+
+        push!(lines, s)
     end
+
+    push!(lines, "  $m constraints")
+
+    for (i, c) in enumerate(constraints)
+        push!(lines, "    [$i] $(c.segments) ∈ $(sprint(summary, only(axiskeys(ds, c))))")
+    end
+
+    print(io, join(lines, "\n"))
 end
 
 """

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -252,8 +252,9 @@
 
         # This is likely to change in the future, so we keep this test simple
         s = sprint(show, ds)
-        @test startswith(s, "KeyedDataset{Tuple{Symbol},")
-        @test occursin("with 2 entries", s)
+        @test startswith(s, "KeyedDataset")
+        @test occursin("2 components", s)
+        @test occursin("3 constraints", s)
     end
 
     @testset "dimpaths" begin


### PR DESCRIPTION
Closes #29 

NOTE: This doesn't have the nice colour coding anymore, but the latency benefit of writing the entire string at once seemed worth it.

You can see the example output [here](https://invenia.github.io/AxisSets.jl/previews/PR35/example/)