### PR TITLE
Fix show method to allow constraints with no current axiskeys

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -86,7 +86,9 @@ function Base.show(io::IO, ds::KeyedDataset{K, T}) where {K, T}
     push!(lines, "  $m constraints")
 
     for (i, c) in enumerate(constraints)
-        push!(lines, "    [$i] $(c.segments) ∈ $(sprint(summary, _only(axiskeys(ds, c))))")
+        _axiskeys = axiskeys(ds, c)
+        key_summary = isempty(_axiskeys) ? "NA" : sprint(summary, _only(_axiskeys))
+        push!(lines, "    [$i] $(c.segments) ∈ $key_summary")
     end
 
     print(io, join(lines, "\n"))

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -255,6 +255,22 @@
         @test startswith(s, "KeyedDataset")
         @test occursin("2 components", s)
         @test occursin("3 constraints", s)
+
+        # Having unused constraints is fine since we might add them later.
+        s = sprint(show, KeyedDataset(pairs(ds.data)...; constraints=Pattern[(:__, :foo)]))
+        @test occursin("2 components", s)
+        @test occursin("1 constraints", s)
+
+        # While possible to construct it's rather pointless to have a dimension path
+        # that can map to multiple constraints.
+        bad_ds = KeyedDataset(
+            pairs(ds.data)...;
+            constraints=Pattern[
+                (:__, :time),
+                (:val1, :time),
+            ],
+        )
+        @test_throws ArgumentError sprint(show, bad_ds)
     end
 
     @testset "dimpaths" begin


### PR DESCRIPTION
You should be able to specify constraints for dimensions / axiskeys that aren't present in the dataset. Currently, our call  to `only` will throw an error in this empty case.