### PR TITLE
Use Patterns to select which components to filter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -112,7 +112,7 @@ julia> [k => parent(parent(v)) for (k, v) in Impute.filter(ds; dims=:time).data]
  (:predict, :load) => [9.0 9.9]
 
 julia> [k => parent(parent(v)) for (k, v) in Impute.filter(ds; dims=:time, pattern=Pattern(:train, :__)).data]
-4-element Array{Pair{Tuple{Symbol,Symbol},Array{Union{Missing, Float64},2}},1}:
+4-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Union{Missing, Float64}}}}:
    (:train, :temp) => [1.0 1.1; 3.0 3.3]
    (:train, :load) => [7.0 7.7; 9.0 9.9]
  (:predict, :temp) => [1.0 missing; 3.0 3.3]

--- a/test/impute.jl
+++ b/test/impute.jl
@@ -90,6 +90,22 @@
         r = Impute.filter(ds; dims=:time)
         @test isequal(r, expected)
 
+        # All time axis are constraint but only :load is checked. :temp is updated to match
+        expected = KeyedDataset(
+            flatten([
+                :train => [
+                    :temp => KeyedArray([1.0 1.1; 3.0 3.3]; time=[1, 3], id=[:a, :b]),
+                    :load => KeyedArray([7.0 7.7; 9.0 9.9]; time=[1, 3], loc=[:x, :y]),
+                ],
+                :predict => [
+                    :temp => KeyedArray([1.0 missing; 3.0 3.3]; time=[1, 3], id=[:a, :b]),
+                    :load => KeyedArray([7.0 7.7; 9.0 9.9]; time=[1, 3], loc=[:x, :y]),
+                ]
+            ])...
+        );
+        r = Impute.filter(ds; dims=:time, pattern=Pattern(:__, :load, :__))
+        @test isequal(r, expected)
+
         # Only :load has a shared :loc axis, so we see that that :y location is dropped from
         # both train and predict.
         expected = KeyedDataset(

--- a/test/impute.jl
+++ b/test/impute.jl
@@ -103,8 +103,14 @@
                 ]
             ])...
         );
-        r = Impute.filter(ds; dims=:time, pattern=Pattern(:__, :load, :__))
+        r = Impute.filter(ds; dims=Pattern(:__, :load, :time))
         @test isequal(r, expected)
+
+        r = Impute.filter(ds; dims=(:__, :load, :time))
+        @test isequal(r, expected)
+
+        # Pattern must end in a dimname
+        @test_throws ArgumentError Impute.filter(ds; dims=Pattern(:__, :load, :_))
 
         # Only :load has a shared :loc axis, so we see that that :y location is dropped from
         # both train and predict.


### PR DESCRIPTION
In some situations it is useful to only filter certain components while updating all shared keys. Some constraints may share a dimname or you might have some components where missing data is acceptable and others where it is not.

This adds an optional `pattern` kwarg to select which tables to remove data from during `filter`. 