### PR TITLE
Loosen component dict type constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/AxisSets.jl
+++ b/src/AxisSets.jl
@@ -67,9 +67,6 @@ julia> axiskeys(flatten(A, (:obj, :loc)), :objᵡloc)
 """
 const DEFAULT_PROD_DELIM = :ᵡ
 
-# Short hand type for complicated union of nested Keyed or NamedDims arrays
-const XArray{L, T, N} = Union{NamedDimsArray{L,T,N,<:KeyedArray}, KeyedArray{T,N,<:NamedDimsArray}}
-
 # There's a few places calling `only` is convenient, even for older Julia releases
 if VERSION < v"1.4"
     function _only(x)

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -98,12 +98,12 @@ function flatten(x::Vector{<:Pair}, delim::Symbol)
     return [Symbol(join(k, delim)) => v for (k, v) in flatten(x)]
 end
 
-function flatten(A::XArray, dims::Tuple, delim=DEFAULT_PROD_DELIM)
+function flatten(A::KeyedArray, dims::Tuple, delim=DEFAULT_PROD_DELIM)
     new_name = Symbol(join(dims, delim))
     flatten(A, dims => new_name, delim)
 end
 
-function flatten(A::XArray, dims::Pair{<:Tuple, Symbol}, delim=nothing)
+function flatten(A::KeyedArray, dims::Pair{<:Tuple, Symbol}, delim=nothing)
     # Lookup our unnamed dimensions to flatten
     # We sort the result to ensure that the dimensions to flatten are consecutive
     fd = sort!(collect(NamedDims.dim(A, first(dims))))

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -105,7 +105,7 @@ julia> ds2 = KeyedDataset(
        );
 
 julia> collect(keys(merge(ds1, ds2).data))
-4-element Vector{Tuple{Symbol}}:
+4-element Vector{Tuple}:
  (:a,)
  (:b,)
  (:c,)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -15,7 +15,7 @@ julia> ds = KeyedDataset(
        );
 
 julia> collect(keys(ds.data))
-2-element Vector{Tuple{Symbol}}:
+2-element Vector{Tuple}:
  (:val1,)
  (:val2,)
 
@@ -154,12 +154,12 @@ julia> ds = KeyedDataset(
        );
 
 julia> collect(keys(ds(:__, :a).data))
-2-element Vector{Tuple{Symbol, Symbol}}:
+2-element Vector{Tuple}:
  (:g1, :a)
  (:g2, :a)
 
 julia> collect(keys(ds(:g1, :__).data))
-2-element Vector{Tuple{Symbol, Symbol}}:
+2-element Vector{Tuple}:
  (:g1, :a)
  (:g1, :b)
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Statistics
 using Test
 using TimeZones
 
-using AxisSets: Pattern, constraintmap, dimpaths, flatten, validate
+using AxisSets: Pattern, KeyedArray, constraintmap, dimpaths, flatten, validate
 using Impute: ThresholdError
 
 @testset "AxisSets.jl" begin


### PR DESCRIPTION
Also, restrict components to `KeyedArray` rather than `XArray`. Reasons for the change.

1. Support empty `KeyedDataset()` constructor which requires loosened key/value type constraints to be useful.
2. We want to support variable types and depths for the keys. If you construct a `KeyedDataset` with only keys `(:train, :input, :load)` and `(:predict, :input, :load)` then adding `(:train, :output)` would error.
3. The `XArray` type (`Union`) was rather verbose and made setting up the correct dispatch harder. Since we don't have a use-case where we want `NamedDimsArray(KeyedArray(...))` I don't think it's worth supporting.

Closes #39 