### PR TITLE
WIP: support FeatureTransforms.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+FeatureTransforms = "8fd68953-04b8-4117-ac19-158bf6de9782"
 Impute = "f7bf1975-0170-51b9-8c5f-a992d46b9575"
 NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -14,6 +15,7 @@ ReadOnlyArrays = "988b38a3-91fc-5605-94a2-ee2116b3bd83"
 [compat]
 AutoHashEquals = "0.2"
 AxisKeys = "0.1"
+FeatureTransforms = "0.3"
 Impute = "0.6"
 NamedDims = "0.2"
 OrderedCollections = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Impute = "0.6"
 NamedDims = "0.2"
 OrderedCollections = "1"
 ReadOnlyArrays = "0.1"
-julia = "1.3"
+julia = "1.5"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/AxisSets.jl
+++ b/src/AxisSets.jl
@@ -2,6 +2,7 @@ module AxisSets
 
 using AutoHashEquals
 using AxisKeys
+using FeatureTransforms
 using Impute
 using NamedDims
 using OrderedCollections
@@ -88,5 +89,7 @@ include("dataset.jl")
 include("indexing.jl")
 include("functions.jl")
 include("impute.jl")
+include("featuretransforms.jl")
+include("utils.jl")
 
 end

--- a/src/AxisSets.jl
+++ b/src/AxisSets.jl
@@ -90,6 +90,5 @@ include("indexing.jl")
 include("functions.jl")
 include("impute.jl")
 include("featuretransforms.jl")
-include("utils.jl")
 
 end

--- a/src/featuretransforms.jl
+++ b/src/featuretransforms.jl
@@ -8,10 +8,14 @@ _transform_pattern(dims) = Pattern[(:__, d) for d in dims]
 """
     FeatureTransforms.apply(ds::KeyedDataset, t::Transform, [key]; dims=:, kwargs...)
 
-Apply the `Transform` to components of the [`KeyedDataset`](@ref) along dimension `dims`.
-The transform can be applied to a subselection of components via a [`Pattern`](@ref) `key`.
+Apply the `Transform` to each component of the [`KeyedDataset`](@ref).
+Returns a new dataset with the same constraints, but transformed components.
 
-Keyword arguments are passed to the equivalent `FeatureTransforms` method for a component.
+The transform can be applied to a subselection of components via a [`Pattern`](@ref) `key`.
+Otherwise, components are selected by the desired `dims`.
+
+Keyword arguments including `dims` are passed to the appropriate `FeatureTransforms` method
+for a component.
 
 # Example
 ```jldoctest
@@ -32,11 +36,13 @@ julia> ds = KeyedDataset(
 
 julia> p = Power(2);
 
-julia> r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :_));
+julia> r = FeatureTransforms.apply(ds, p, (:_, :price, :_));
 
 julia> [k => parent(parent(v)) for (k, v) in r.data]
-2-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Float64}}}:
+4-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Float64}}}:
+    (:train, :load) => [7.0 7.7; 8.0 8.2; 9.0 9.9]
    (:train, :price) => [4.0 16.0; 9.0 4.0; 1.0 1.0]
+  (:predict, :load) => [7.0 7.7; 8.1 7.9; 9.0 9.9]
  (:predict, :price) => [0.25 1.0; 25.0 4.0; 0.0 1.0]
 ```
 """
@@ -52,11 +58,14 @@ end
 """
     FeatureTransforms.apply!(ds::KeyedDataset, t::Transform, [key]; dims=:, kwargs...)
 
-Apply the `Transform` to components of the [`KeyedDataset`](@ref) along dimension `dims`,
-mutating the components in-place.
-The transform can be applied to a subselection of components via a [`Pattern`](@ref) `key`.
+Apply the `Transform` to each component of the [`KeyedDataset`](@ref).
+Returns a new dataset with the same constraints, but transformed components.
 
-Keyword arguments are passed to the equivalent `FeatureTransforms` method for a component.
+The transform can be applied to a subselection of components via a [`Pattern`](@ref) `key`.
+Otherwise, components are selected by the desired `dims`.
+
+Keyword arguments including `dims` are passed to the appropriate `FeatureTransforms` method
+for a component.
 """
 function FeatureTransforms.apply!(
     ds::KeyedDataset, t::Transform, keys...;
@@ -68,12 +77,55 @@ function FeatureTransforms.apply!(
 end
 
 """
-    FeatureTransforms.apply_append(ds::KeyedDataset, t::Transform, [key]; dims=:, kwargs...)
+    FeatureTransforms.apply_append(
+        ds::KeyedDataset, t::Transform, [key];
+        dims=:, inner=false, component_name=:component, kwargs...
+    )
 
-Apply the `Transform` to components of the [`KeyedDataset`](@ref) along dimension `dims`.
+Apply the `Transform` to each component of the [`KeyedDataset`](@ref).
+
 The transform can be applied to a subselection of components via a [`Pattern`](@ref) `key`.
+Otherwise, components are selected by the desired `dims`.
 
-Keyword arguments are passed to the equivalent `FeatureTransforms` method for a component.
+If `inner=true`, perform `FeatureTransforms.apply_append` on each component,
+returning a new dataset with the same constraints, but transformed components.
+
+Otherwise, transform each component using `FeatureTransforms.apply`, and append
+to a copy of the dataset as a new component called `component_name`.
+
+Keyword arguments including `dims` are passed to the appropriate `FeatureTransforms` method
+for a component.
+
+# Example
+```jldoctest
+julia> using AxisKeys, FeatureTransforms; using AxisSets: KeyedDataset, Pattern, flatten;
+
+julia> ds = KeyedDataset(
+           flatten([
+               :train => [
+                   :load => KeyedArray([7.0 7.7; 8.0 8.2; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                   :price => KeyedArray([-2.0 4.0; 3.0 2.0; -1.0 -1.0]; time=1:3, id=[:a, :b]),
+               ],
+               :predict => [
+                   :load => KeyedArray([7.0 7.7; 8.1 7.9; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                   :price => KeyedArray([0.5 -1.0; -5.0 -2.0; 0.0 1.0]; time=1:3, id=[:a, :b]),
+               ]
+           ])...
+       );
+
+julia> p = Power(2);
+
+julia> r = FeatureTransforms.apply_append(ds, p, (:_, :price, :_); component_name=:price2);
+
+julia> [k => parent(parent(v)) for (k, v) in r.data]
+6-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Float64}}}:
+     (:train, :load) => [7.0 7.7; 8.0 8.2; 9.0 9.9]
+    (:train, :price) => [-2.0 4.0; 3.0 2.0; -1.0 -1.0]
+   (:predict, :load) => [7.0 7.7; 8.1 7.9; 9.0 9.9]
+  (:predict, :price) => [0.5 -1.0; -5.0 -2.0; 0.0 1.0]
+   (:train, :price2) => [4.0 16.0; 9.0 4.0; 1.0 1.0]
+ (:predict, :price2) => [0.25 1.0; 25.0 4.0; 0.0 1.0]
+```
 """
 function FeatureTransforms.apply_append(
     ds::KeyedDataset, t::Transform, keys...;

--- a/src/featuretransforms.jl
+++ b/src/featuretransforms.jl
@@ -25,11 +25,11 @@ julia> ds = KeyedDataset(
 
 julia> p = Power(2);
 
-julia> [k => parent(parent(v)) for (k, v) in FeatureTransforms.apply(ds, p; dims=(:_, :price, :_)).data]
-4-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Float64}}}:
-    (:train, :load) => [7.0 7.7; 8.0 8.2; 9.0 9.9]
+julia> r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :_));
+
+julia> [k => parent(parent(v)) for (k, v) in r.data]
+2-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Float64}}}:
    (:train, :price) => [4.0 16.0; 9.0 4.0; 1.0 1.0]
-  (:predict, :load) => [7.0 7.7; 8.1 7.9; 9.0 9.9]
  (:predict, :price) => [0.25 1.0; 25.0 4.0; 0.0 1.0]
 ```
 """
@@ -47,10 +47,10 @@ function FeatureTransforms.apply(ds::KeyedDataset, t::Transform; dims, kwargs...
         apply_paths = unique(apply_paths)
     end
 
-    for path in apply_paths
+    pairs = map(apply_paths) do path
         component = ds.data[path]
-        ds.data[path] = FeatureTransforms.apply(component, t; dims=dim, kwargs...)
+        path => FeatureTransforms.apply(component, t; dims=dim, kwargs...)
     end
 
-    return ds
+    return KeyedDataset(pairs...)
 end

--- a/src/featuretransforms.jl
+++ b/src/featuretransforms.jl
@@ -77,7 +77,7 @@ Keyword arguments are passed to the equivalent `FeatureTransforms` method for a 
 """
 function FeatureTransforms.apply_append(
     ds::KeyedDataset, t::Transform, keys...;
-    inner=false, component_name=nothing, dims=:, kwargs...
+    dims=:, inner=false, component_name=:component, kwargs...
 )
     patterns = _transform_pattern(keys, dims)
 
@@ -90,10 +90,7 @@ function FeatureTransforms.apply_append(
         selected = unique(x[1:end-1] for x in dimpaths(ds) if any(p -> x in p, patterns))
 
         # construct keys of new transformed components
-        new_keys = map(selected) do k
-            component_name = isnothing(component_name) ? :component : component_name
-            (k[1:end-1]..., component_name)
-        end
+        new_keys = [(k[1:end-1]..., component_name) for k in selected]
 
         # pair new keys with transformed components
         pairs = map(new_keys, selected) do new_k, k

--- a/src/featuretransforms.jl
+++ b/src/featuretransforms.jl
@@ -1,0 +1,56 @@
+FeatureTransforms.is_transformable(::KeyedDataset) = true
+
+"""
+    FeatureTransforms.apply(ds::KeyedDataset, t::Transform; dims=:, kwargs...)
+
+Apply the `Transform` along the `dims` for each component in the [`KeyedDataset`](@ref)
+with that dimension.
+
+# Example
+```jldoctest
+julia> using AxisKeys, FeatureTransforms; using AxisSets: KeyedDataset, Pattern, flatten;
+
+julia> ds = KeyedDataset(
+           flatten([
+               :train => [
+                   :load => KeyedArray([7.0 7.7; 8.0 8.2; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                   :price => KeyedArray([-2.0 4.0; 3.0 2.0; -1.0 -1.0]; time=1:3, id=[:a, :b]),
+               ],
+               :predict => [
+                   :load => KeyedArray([7.0 7.7; 8.1 7.9; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                   :price => KeyedArray([0.5 -1.0; -5.0 -2.0; 0.0 1.0]; time=1:3, id=[:a, :b]),
+               ]
+           ])...
+       );
+
+julia> p = Power(2);
+
+julia> [k => parent(parent(v)) for (k, v) in FeatureTransforms.apply(ds, p; dims=(:_, :price, :_)).data]
+4-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Float64}}}:
+    (:train, :load) => [7.0 7.7; 8.0 8.2; 9.0 9.9]
+   (:train, :price) => [4.0 16.0; 9.0 4.0; 1.0 1.0]
+  (:predict, :load) => [7.0 7.7; 8.1 7.9; 9.0 9.9]
+ (:predict, :price) => [0.25 1.0; 25.0 4.0; 0.0 1.0]
+```
+"""
+function FeatureTransforms.apply(ds::KeyedDataset, t::Transform; dims, kwargs...)
+    pattern = _pattern(dims)
+    dim = pattern.segments[end]
+
+    # Get paths to components
+    apply_paths = dimpaths(ds, pattern)
+    apply_paths = [p[1:end-1] for p in apply_paths]
+
+    if dim in (:_, :__)
+        # Corresponds to element-wise apply in FeatureTransforms
+        dim = Colon()
+        apply_paths = unique(apply_paths)
+    end
+
+    for path in apply_paths
+        component = ds.data[path]
+        ds.data[path] = FeatureTransforms.apply(component, t; dims=dim, kwargs...)
+    end
+
+    return ds
+end

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -126,10 +126,6 @@ julia> [k => parent(parent(v)) for (k, v) in Impute.filter(ds; dims=:loc).data]
 """
 Impute.apply(ds::KeyedDataset, f::Filter; dims) = Impute.apply!(deepcopy(ds), f; dims=dims)
 
-_pattern(dims::Pattern) = dims
-_pattern(dims::Tuple) = Pattern(dims)
-_pattern(dims) = Pattern(:__, dims)
-
 function Impute.apply!(ds::KeyedDataset, f::Filter; dims)
     pattern = _pattern(dims)
     dim = pattern.segments[end]

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -126,12 +126,12 @@ julia> [k => parent(parent(v)) for (k, v) in Impute.filter(ds; dims=:loc).data]
 """
 Impute.apply(ds::KeyedDataset, f::Filter; dims) = Impute.apply!(deepcopy(ds), f; dims=dims)
 
-_pattern(dims::Pattern) = dims
-_pattern(dims::Tuple) = Pattern(dims)
-_pattern(dims) = Pattern(:__, dims)
+_impute_pattern(dims::Pattern) = dims
+_impute_pattern(dims::Tuple) = Pattern(dims)
+_impute_pattern(dims) = Pattern(:__, dims)
 
 function Impute.apply!(ds::KeyedDataset, f::Filter; dims)
-    pattern = _pattern(dims)
+    pattern = _impute_pattern(dims)
     dim = pattern.segments[end]
 
     dim in (:_, :__) && throw(ArgumentError(

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -126,6 +126,10 @@ julia> [k => parent(parent(v)) for (k, v) in Impute.filter(ds; dims=:loc).data]
 """
 Impute.apply(ds::KeyedDataset, f::Filter; dims) = Impute.apply!(deepcopy(ds), f; dims=dims)
 
+_pattern(dims::Pattern) = dims
+_pattern(dims::Tuple) = Pattern(dims)
+_pattern(dims) = Pattern(:__, dims)
+
 function Impute.apply!(ds::KeyedDataset, f::Filter; dims)
     pattern = _pattern(dims)
     dim = pattern.segments[end]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,5 @@
 # Convert a dims argument to a Pattern
 _pattern(dims::Pattern) = dims
 _pattern(dims::Tuple) = Pattern(dims)
+_pattern(::Colon) = Pattern(:__)
 _pattern(dims) = Pattern(:__, dims)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,0 @@
-# Convert a dims argument to a Pattern
-_pattern(dims::Pattern) = dims
-_pattern(dims::Tuple) = Pattern(dims)
-_pattern(::Colon) = Pattern(:__)
-_pattern(dims) = Pattern(:__, dims)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,4 @@
+# Convert a dims argument to a Pattern
+_pattern(dims::Pattern) = dims
+_pattern(dims::Tuple) = Pattern(dims)
+_pattern(dims) = Pattern(:__, dims)

--- a/test/featuretransforms.jl
+++ b/test/featuretransforms.jl
@@ -1,13 +1,17 @@
 @testset "FeatureTransforms" begin
+    M1 = [0.0 1.0; 1.0 2.0; -0.5 0.0]
+    M2 = [-2.0 4.0; 3.0 2.0; -1.0 -1.0]
+    M3 = [0.0 1.0; -1.0 0.5; -0.5 0.0]
+    M4 = [0.5 -1.0; -5.0 -2.0; 0.0 1.0]
     ds = KeyedDataset(
         flatten([
             :train => [
-                :load => KeyedArray([7.0 7.7; 8.0 8.2; 9.0 9.9]; time=1:3, loc=[:x, :y]),
-                :price => KeyedArray([-2.0 4.0; 3.0 2.0; -1.0 -1.0]; time=1:3, id=[:a, :b]),
+                :load => KeyedArray(M1; time=1:3, loc=[:x, :y]),
+                :price => KeyedArray(M2; time=1:3, id=[:a, :b]),
             ],
             :predict => [
-                :load => KeyedArray([7.0 7.7; 8.1 7.9; 9.0 9.9]; time=1:3, loc=[:x, :y]),
-                :price => KeyedArray([0.5 -1.0; -5.0 -2.0; 0.0 1.0]; time=1:3, id=[:a, :b]),
+                :load => KeyedArray(M3; time=1:3, loc=[:x, :y]),
+                :price => KeyedArray(M4; time=1:3, id=[:a, :b]),
             ]
         ])...
     )
@@ -16,39 +20,107 @@
         @test is_transformable(ds)
     end
 
-    @testset "apply" begin
+    # TODO: use fake Transforms
+    @testset "apply OneToOne" begin
         p = Power(2)
 
-        expected = KeyedDataset(
-            flatten([
-                :train => [
-                    :price => KeyedArray([4.0 16.0; 9.0 4.0; 1.0 1.0]; time=1:3, id=[:a, :b]),
-                ],
-                :predict => [
-                    :price => KeyedArray([0.25 1.0; 25.0 4.0; 0.0 1.0]; time=1:3, id=[:a, :b]),
-                ]
-            ])...
-        )
+        @testset "apply" begin
+            @testset "one feature" begin
+                expected = KeyedDataset(
+                    flatten([
+                        :train => [
+                            :price => KeyedArray(M2.^2; time=1:3, id=[:a, :b]),
+                        ],
+                        :predict => [
+                            :price => KeyedArray(M4.^2; time=1:3, id=[:a, :b]),
+                        ]
+                    ])...
+                )
 
-        r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :_))
+                r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :_))
 
-        @test r isa KeyedDataset
-        @test isequal(r, expected)
+                @test r isa KeyedDataset
+                @test isequal(r, expected)
+            end
 
-        expected = KeyedDataset(
-            flatten([
-                :train => [
-                    :price => KeyedArray(hcat([16.0; 4.0; 1.0]); time=1:3, id=[:b]),
-                ],
-                :predict => [
-                    :price => KeyedArray(hcat([1.0; 4.0; 1.0]); time=1:3, id=[:b]),
-                ]
-            ])...
-        )
+            @testset "all features" begin
+                expected = KeyedDataset(
+                    flatten([
+                        :train => [
+                            :load => KeyedArray(M1.^2; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M2.^2; time=1:3, id=[:a, :b]),
+                        ],
+                        :predict => [
+                            :load => KeyedArray(M3.^2; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M4.^2; time=1:3, id=[:a, :b]),
+                        ]
+                    ])...
+                )
 
-        r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :id), inds=[2])
+                r = FeatureTransforms.apply(ds, p; dims=:)
 
-        @test r isa KeyedDataset
-        @test isequal(r, expected)
+                @test r isa KeyedDataset
+                @test isequal(r, expected)
+            end
+
+            @testset "inds" begin
+                expected = KeyedDataset(
+                    flatten([
+                        :train => [
+                            :price => KeyedArray(hcat((M2.^2)[:, 2]); time=1:3, id=[:b]),
+                        ],
+                        :predict => [
+                            :price => KeyedArray(hcat((M4.^2)[:, 2]); time=1:3, id=[:b]),
+                        ]
+                    ])...
+                )
+
+                r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :id), inds=[2])
+
+                @test r isa KeyedDataset
+                @test isequal(r, expected)
+            end
+        end
+
+        @testset "apply!" begin
+            expected = KeyedDataset(
+                flatten([
+                    :train => [
+                        :load => KeyedArray(M1; time=1:3, loc=[:x, :y]),
+                        :price => KeyedArray(M2.^2; time=1:3, id=[:a, :b]),
+                    ],
+                    :predict => [
+                        :load => KeyedArray(M3; time=1:3, loc=[:x, :y]),
+                        :price => KeyedArray(M4.^2; time=1:3, id=[:a, :b]),
+                    ]
+                ])...
+            )
+
+            r = FeatureTransforms.apply!(ds, p; dims=(:_, :price, :_))
+
+            @test isequal(ds, expected)
+            @test r isa KeyedDataset
+            @test isequal(r, expected)
+        end
+
+        @testset "apply_append" begin
+            M2_cat = cat(M2, M2.^2, dims=2)
+            M4_cat = cat(M4, M4.^2, dims=2)
+            expected = KeyedDataset(
+                flatten([
+                    :train => [
+                        :price => KeyedArray(M2_cat; time=1:3, id=[:a, :b, :a, :b]),
+                    ],
+                    :predict => [
+                        :price => KeyedArray(M4_cat; time=1:3, id=[:a, :b, :a, :b]),
+                    ]
+                ])...
+            )
+
+            r = FeatureTransforms.apply_append(ds, p; dims=(:_, :price, :_), append_dim=2)
+
+            @test r isa KeyedDataset
+            @test isequal(r, expected)
+        end
     end
 end

--- a/test/featuretransforms.jl
+++ b/test/featuretransforms.jl
@@ -179,7 +179,7 @@
 
                 r = FeatureTransforms.apply_append(
                     ds, p, (:_, :price, :_);
-                    component_name=:price2, append_dim=2
+                    component_name=:price2
                 )
 
                 @test r isa KeyedDataset

--- a/test/featuretransforms.jl
+++ b/test/featuretransforms.jl
@@ -134,6 +134,57 @@
 
                 @test r isa KeyedDataset
                 @test isequal(r, expected)
+                @test !isequal(ds, expected)
+            end
+
+            @testset "outer" begin
+                M2_cat = cat(M2, M2.^2, dims=2)
+                M4_cat = cat(M4, M4.^2, dims=2)
+
+                expected = KeyedDataset(
+                    flatten([
+                        :train => [
+                            :load => KeyedArray(M1; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M2; time=1:3, id=[:a, :b]),
+                            :component => KeyedArray(M2.^2; time=1:3, id=[:a, :b]),
+                        ],
+                        :predict => [
+                            :load => KeyedArray(M3; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M4; time=1:3, id=[:a, :b]),
+                            :component => KeyedArray(M4.^2; time=1:3, id=[:a, :b]),
+                        ]
+                    ])...
+                )
+
+                r = FeatureTransforms.apply_append(ds, p, (:_, :price, :_); append_dim=2)
+
+                @test r isa KeyedDataset
+                @test isequal(r, expected)
+                @test !isequal(ds, expected)
+
+                expected = KeyedDataset(
+                    flatten([
+                        :train => [
+                            :load => KeyedArray(M1; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M2; time=1:3, id=[:a, :b]),
+                            :price2 => KeyedArray(M2.^2; time=1:3, id=[:a, :b]),
+                        ],
+                        :predict => [
+                            :load => KeyedArray(M3; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M4; time=1:3, id=[:a, :b]),
+                            :price2 => KeyedArray(M4.^2; time=1:3, id=[:a, :b]),
+                        ]
+                    ])...
+                )
+
+                r = FeatureTransforms.apply_append(
+                    ds, p, (:_, :price, :_);
+                    component_name=:price2, append_dim=2
+                )
+
+                @test r isa KeyedDataset
+                @test isequal(r, expected)
+                @test !isequal(ds, expected)
             end
         end
     end

--- a/test/featuretransforms.jl
+++ b/test/featuretransforms.jl
@@ -1,0 +1,40 @@
+@testset "FeatureTransforms" begin
+    ds = KeyedDataset(
+        flatten([
+            :train => [
+                :load => KeyedArray([7.0 7.7; 8.0 8.2; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                :price => KeyedArray([-2.0 4.0; 3.0 2.0; -1.0 -1.0]; time=1:3, id=[:a, :b]),
+            ],
+            :predict => [
+                :load => KeyedArray([7.0 7.7; 8.1 7.9; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                :price => KeyedArray([0.5 -1.0; -5.0 -2.0; 0.0 1.0]; time=1:3, id=[:a, :b]),
+            ]
+        ])...
+    )
+
+    @testset "transform" begin
+        @test is_transformable(ds)
+    end
+
+    @testset "apply" begin
+        p = Power(2)
+
+        expected = KeyedDataset(
+            flatten([
+                :train => [
+                    :load => KeyedArray([7.0 7.7; 8.0 8.2; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                    :price => KeyedArray([4.0 16.0; 9.0 4.0; 1.0 1.0]; time=1:3, id=[:a, :b]),
+                ],
+                :predict => [
+                    :load => KeyedArray([7.0 7.7; 8.1 7.9; 9.0 9.9]; time=1:3, loc=[:x, :y]),
+                    :price => KeyedArray([0.25 1.0; 25.0 4.0; 0.0 1.0]; time=1:3, id=[:a, :b]),
+                ]
+            ])...
+        )
+
+        r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :_))
+
+        @test r isa KeyedDataset
+        @test isequal(r, expected)
+    end
+end

--- a/test/featuretransforms.jl
+++ b/test/featuretransforms.jl
@@ -22,17 +22,31 @@
         expected = KeyedDataset(
             flatten([
                 :train => [
-                    :load => KeyedArray([7.0 7.7; 8.0 8.2; 9.0 9.9]; time=1:3, loc=[:x, :y]),
                     :price => KeyedArray([4.0 16.0; 9.0 4.0; 1.0 1.0]; time=1:3, id=[:a, :b]),
                 ],
                 :predict => [
-                    :load => KeyedArray([7.0 7.7; 8.1 7.9; 9.0 9.9]; time=1:3, loc=[:x, :y]),
                     :price => KeyedArray([0.25 1.0; 25.0 4.0; 0.0 1.0]; time=1:3, id=[:a, :b]),
                 ]
             ])...
         )
 
         r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :_))
+
+        @test r isa KeyedDataset
+        @test isequal(r, expected)
+
+        expected = KeyedDataset(
+            flatten([
+                :train => [
+                    :price => KeyedArray(hcat([16.0; 4.0; 1.0]); time=1:3, id=[:b]),
+                ],
+                :predict => [
+                    :price => KeyedArray(hcat([1.0; 4.0; 1.0]); time=1:3, id=[:b]),
+                ]
+            ])...
+        )
+
+        r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :id), inds=[2])
 
         @test r isa KeyedDataset
         @test isequal(r, expected)

--- a/test/featuretransforms.jl
+++ b/test/featuretransforms.jl
@@ -29,18 +29,21 @@
                 expected = KeyedDataset(
                     flatten([
                         :train => [
+                            :load => KeyedArray(M1; time=1:3, loc=[:x, :y]),
                             :price => KeyedArray(M2.^2; time=1:3, id=[:a, :b]),
                         ],
                         :predict => [
+                            :load => KeyedArray(M3; time=1:3, loc=[:x, :y]),
                             :price => KeyedArray(M4.^2; time=1:3, id=[:a, :b]),
                         ]
                     ])...
                 )
 
-                r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :_))
+                r = FeatureTransforms.apply(ds, p, (:_, :price, :_))
 
                 @test r isa KeyedDataset
                 @test isequal(r, expected)
+                @test !isequal(ds, expected)
             end
 
             @testset "all features" begin
@@ -61,24 +64,28 @@
 
                 @test r isa KeyedDataset
                 @test isequal(r, expected)
+                @test !isequal(ds, expected)
             end
 
             @testset "inds" begin
                 expected = KeyedDataset(
                     flatten([
                         :train => [
+                            :load => KeyedArray(M1; time=1:3, loc=[:x, :y]),
                             :price => KeyedArray(hcat((M2.^2)[:, 2]); time=1:3, id=[:b]),
                         ],
                         :predict => [
+                            :load => KeyedArray(M3; time=1:3, loc=[:x, :y]),
                             :price => KeyedArray(hcat((M4.^2)[:, 2]); time=1:3, id=[:b]),
                         ]
                     ])...
                 )
 
-                r = FeatureTransforms.apply(ds, p; dims=(:_, :price, :id), inds=[2])
+                r = FeatureTransforms.apply(ds, p, (:_, :price, :_); dims=:id, inds=[2])
 
                 @test r isa KeyedDataset
                 @test isequal(r, expected)
+                @test !isequal(ds, expected)
             end
         end
 
@@ -96,31 +103,38 @@
                 ])...
             )
 
-            r = FeatureTransforms.apply!(ds, p; dims=(:_, :price, :_))
+            r = FeatureTransforms.apply!(ds, p, (:_, :price, :_))
 
-            @test isequal(ds, expected)
             @test r isa KeyedDataset
             @test isequal(r, expected)
+            @test isequal(ds, expected)
         end
 
         @testset "apply_append" begin
-            M2_cat = cat(M2, M2.^2, dims=2)
-            M4_cat = cat(M4, M4.^2, dims=2)
-            expected = KeyedDataset(
-                flatten([
-                    :train => [
-                        :price => KeyedArray(M2_cat; time=1:3, id=[:a, :b, :a, :b]),
-                    ],
-                    :predict => [
-                        :price => KeyedArray(M4_cat; time=1:3, id=[:a, :b, :a, :b]),
-                    ]
-                ])...
-            )
+            @testset "inner" begin
+                M2_cat = cat(M2, M2.^2, dims=2)
+                M4_cat = cat(M4, M4.^2, dims=2)
+                expected = KeyedDataset(
+                    flatten([
+                        :train => [
+                            :load => KeyedArray(M1; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M2_cat; time=1:3, id=[:a, :b, :a, :b]),
+                        ],
+                        :predict => [
+                            :load => KeyedArray(M3; time=1:3, loc=[:x, :y]),
+                            :price => KeyedArray(M4_cat; time=1:3, id=[:a, :b, :a, :b]),
+                        ]
+                    ])...
+                )
 
-            r = FeatureTransforms.apply_append(ds, p; dims=(:_, :price, :_), append_dim=2)
+                r = FeatureTransforms.apply_append(
+                    ds, p, (:_, :price, :_);
+                    inner=true, append_dim=2
+                )
 
-            @test r isa KeyedDataset
-            @test isequal(r, expected)
+                @test r isa KeyedDataset
+                @test isequal(r, expected)
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using AxisKeys
 using AxisSets
 using Dates
 using Documenter
+using FeatureTransforms
 using Impute
 using Missings
 using OrderedCollections
@@ -20,6 +21,7 @@ using Impute: ThresholdError
     include("indexing.jl")
     include("functions.jl")
     include("impute.jl")
+    include("featuretransforms.jl")
 
     # The doctests fail on x86, so only run them on 64-bit hardware & Julia 1.6
     Sys.WORD_SIZE == 64 && v"1.6" <= VERSION < v"1.7" && doctest(AxisSets)


### PR DESCRIPTION
Part of #12 

Implements `is_transformable`, `apply`, `apply!`, `apply_append` methods for `KeyedDataset`.

The scope of my thinking has been mostly limited to one-to-one `Transform`s. `LinearCombination` won't work yet. Also, `AbstractScaling` is inconvenient and could have its own special method (see further below).

Some further comments to discuss or note are in the diff.

----

Scaling is currently complicated (I might be missing an easier way to access the data, but nonetheless):

```julia
julia> only(ds(:train, :price).data)
(:train, :price) => [-2.0 4.0; 3.0 2.0; -1.0 -1.0]

julia> scaling = MeanStdScaling(only(ds(:train, :price).data)[2]; dims=:id, inds=[2]);

julia> r = scaling(ds; dims=:id, inds=[2])
KeyedDataset with:
  2 components
    (:train, :price) => 3x1 KeyedArray{Float64} with dimension time[1], id[2]
    (:predict, :price) => 3x1 KeyedArray{Float64} with dimension time[1], id[2]
  2 constraints
    [1] (:__, :time) ∈ 3-element UnitRange{Int64}
    [2] (:__, :id) ∈ 1-element Vector{Symbol}

julia> only(r(:train, :price).data)[2]
2-dimensional KeyedArray(NamedDimsArray(...)) with keys:
↓   time ∈ 3-element UnitRange{Int64}
→   id ∈ 1-element Vector{Symbol}And data, 3×1 Matrix{Float64}:
      (:b) (1)   0.9271726499455306
 (2)   0.13245323570650436
 (3)  -1.0596258856520353
```

In addition (or alternative) to implementing `MeanStdScaling(::KeyedDataset; dims)`, addressing the below issues would help improve the above:

https://github.com/invenia/FeatureTransforms.jl/issues/59
https://github.com/invenia/FeatureTransforms.jl/issues/56