### PR TITLE
Throw a more specific key alignment error during validation 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -6,8 +6,8 @@ Is thrown when the constrained dimensions of components in a `KeyedDataset` have
 key values.
 
 # Fields
-* constraint::Pattern - The constraint descript all patch dimension keys
-* groups - An iterator of paths and keys for each non-matching group.
+* constraint::Pattern - Constraint pattern describing all dimensions that must align
+* groups - An iterator of paths and keys for each non-matching group
 """
 struct KeyAlignmentError <: Exception
     constraint::Pattern

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -110,8 +110,9 @@ julia> collect(constraintmap(ds))
   Pattern((:__, :lag)) => Set([(:b, :lag)])
 
 julia> ds[:c] = KeyedArray(ones(3, 2); time=2:4, lag=[-1, -2])
-ERROR: ArgumentError: Shared dimensions don't have matching keys
-
+ERROR: KeyAlignmentError: Misaligned dimension keys on constraint Pattern((:__, :time))
+  Tuple[(:b, :time), (:a, :time)] ∈ 3-element UnitRange{Int64}
+  Tuple[(:c, :time)] ∈ 3-element UnitRange{Int64}
 ```
 """
 Base.setindex!(ds::KeyedDataset, val, key::Symbol) = setindex!(ds, val, (key,))

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -2,7 +2,7 @@
     @testset "Construction" begin
         @testset "Invalid" begin
             # Test that you can construct an invalid dataset if you really want to
-            @test_throws ArgumentError KeyedDataset(
+            @test_throws KeyAlignmentError KeyedDataset(
                 OrderedSet(Pattern[(:__, :time)]),
                 LittleDict(
                     (:val1,) => KeyedArray(rand(4); time=1:4),
@@ -18,7 +18,7 @@
                 ),
                 false
             )
-            @test_throws ArgumentError validate(ds)
+            @test_throws KeyAlignmentError validate(ds)
         end
 
         @testset "Empty" begin
@@ -410,8 +410,8 @@
             obj=[:a, :b],
         )
 
-        @test_throws ArgumentError validate(ds)
-        @test_throws ArgumentError validate(ds, Pattern(:__, :time))
+        @test_throws KeyAlignmentError validate(ds)
+        @test_throws KeyAlignmentError validate(ds, Pattern(:__, :time))
         @test validate(ds, Pattern(:__, :obj))
     end
 end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -84,7 +84,7 @@ end
     end
 
     # Reducing over time will violate our :time dimension constraint
-    @test_throws ArgumentError mapslices(sum, ds, (:__, :b, :_); dims=:time)
+    @test_throws KeyAlignmentError mapslices(sum, ds, (:__, :b, :_); dims=:time)
     # Dimension doesn't exist in the selection
     @test_throws ArgumentError mapslices(sum, ds, (:__, :b, :_); dims=:foo)
 end
@@ -152,7 +152,7 @@ end
                 obj=[:a, :b],
             )
         )
-        @test_throws ArgumentError merge(ds1, ds2)
+        @test_throws KeyAlignmentError merge(ds1, ds2)
     end
 end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -120,7 +120,7 @@ end
 
     # Test validation error if we try to add a component with a mismatched dimension
     # relative to our existing dimensions / constraints
-    @test_throws ArgumentError setindex!(ds, KeyedArray(rand(2); id=[1, 2]), :d)
+    @test_throws KeyAlignmentError setindex!(ds, KeyedArray(rand(2); id=[1, 2]), :d)
 end
 
 @testset "lookup" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,14 @@ using Statistics
 using Test
 using TimeZones
 
-using AxisSets: Pattern, KeyedArray, constraintmap, dimpaths, flatten, validate
+using AxisSets:
+    Pattern,
+    KeyAlignmentError,
+    KeyedDataset,
+    constraintmap,
+    dimpaths,
+    flatten,
+    validate
 using Impute: ThresholdError
 
 @testset "AxisSets.jl" begin


### PR DESCRIPTION
Listing the constraint, paths and keys that mismatched. Closes #27 

Error now now looks like:

```julia
julia> ds = KeyedDataset(
                  :val1 => KeyedArray(rand(4, 3, 2); time=1:4, loc=-1:-1:-3, obj=[:a, :b]),
                  :val2 => KeyedArray(rand(4, 3, 2) .+ 1.0; time=0:3, loc=-1:-1:-3, obj=[:a, :b]),
              )
ERROR: KeyAlignmentError: Misaligned dimension keys on constraint Pattern((:__, :time))
  Tuple[(:val2, :time)] ∈ 4-element UnitRange{Int64}
  Tuple[(:val1, :time)] ∈ 4-element UnitRange{Int64}
```

It doesn't tell you the exact mismatched values as:

1. These keys could be too large to reasonably print in the error
2. We may have more than 2 groups of mismatch key values, so something like DeepDiffs.jl wouldn't really work here either.