### PR TITLE
Drop default delimiters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.7"
+version = "0.2.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -54,8 +54,6 @@ function misrand(factor, id)::Union{Missing, Float64}
     return rand(rng)
 end
 
-
-
 data = (
     train = (
         input = (
@@ -111,7 +109,8 @@ To make things easier we're gonna flatten our nested structure and display the c
 
 ```@example full
 flattened = AxisSets.flatten(data)
-Dict(k => names(v) for (k, v) in pairs(flattened))
+d = Dict(flattened...)
+Dict(k => names(v) for (k, v) in flattened)
 ```
 
 Something you may notice about our data is that each component has a `:time` and `:id` column which uniquely identify each value.
@@ -120,7 +119,7 @@ Therefore we can more compactly represent our components as `AxisKeys.KeyedArray
 ```@example full
 components = (
     k => allowmissing(wrapdims(v, Tables.columnnames(v)[end], Tables.columnnames(v)[1:end-1]...))
-    for (k, v) in pairs(flattened)
+    for (k, v) in flattened
 )
 ```
 
@@ -132,15 +131,15 @@ For example, the `:time` columns across `train_input` tables align.
 Similarly the `:id` columns match for both `train_input_prices` and `train_output_prices`.
 
 ```@example full
-@assert issetequal(flattened.train_input_temp.time, flattened.train_input_load.time)
-@assert issetequal(flattened.train_input_prices.id, flattened.train_output_prices.id)
+@assert issetequal(d[(:train, :input, :temp)].time, d[(:train, :input, :load)].time)
+@assert issetequal(d[(:train, :input, :prices)].id, d[(:train, :output, :prices)].id)
 ```
 
 However, not all `time` or `id` columns need to align.
 
 ```@example full
-@assert !issetequal(flattened.train_input_prices.time, flattened.train_output_prices.time)
-@assert !issetequal(flattened.train_input_temp.id, flattened.train_input_load.id)
+@assert !issetequal(d[(:train, :input, :prices)].time, d[(:train, :output, :prices)].time)
+@assert !issetequal(d[(:train, :input, :temp)].id, d[(:train, :input, :load)].id)
 ```
 
 It turns out we can summarize these alignment "constraints" pretty concisely.

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -128,19 +128,19 @@ This representation avoids storing duplicate `:time` and `:id` column values and
 
 If we look a little closer we'll also find that several of these "key" columns align across the dataframes, while others do not.
 
-For example, the `:time` columns across `train⁻input` tables align.
-Similarly the `:id` columns match for both `train⁻input⁻prices` and `train⁻output⁻prices`.
+For example, the `:time` columns across `train_input` tables align.
+Similarly the `:id` columns match for both `train_input_prices` and `train_output_prices`.
 
 ```@example full
-@assert issetequal(flattened.train⁻input⁻temp.time, flattened.train⁻input⁻load.time)
-@assert issetequal(flattened.train⁻input⁻prices.id, flattened.train⁻output⁻prices.id)
+@assert issetequal(flattened.train_input_temp.time, flattened.train_input_load.time)
+@assert issetequal(flattened.train_input_prices.id, flattened.train_output_prices.id)
 ```
 
 However, not all `time` or `id` columns need to align.
 
 ```@example full
-@assert !issetequal(flattened.train⁻input⁻prices.time, flattened.train⁻output⁻prices.time)
-@assert !issetequal(flattened.train⁻input⁻temp.id, flattened.train⁻input⁻load.id)
+@assert !issetequal(flattened.train_input_prices.time, flattened.train_output_prices.time)
+@assert !issetequal(flattened.train_input_temp.id, flattened.train_input_load.id)
 ```
 
 It turns out we can summarize these alignment "constraints" pretty concisely.

--- a/src/AxisSets.jl
+++ b/src/AxisSets.jl
@@ -12,62 +12,6 @@ using Impute: DeclareMissings, Filter, Imputor, Validator
 
 export KeyedDataset
 
-"""
-    DEFAULT_FLATTEN_DELIM
-
-`:⁻` (or `\\^-`)
-
-Separates the parent symbols of a nested `NamedTuple` that has been flattened.
-A less common symbol was used to avoid collisions with `:_` in the parent symbols.
-
-# Example
-```jldoctest
-julia> using AxisSets: flatten
-
-julia> data = (
-           val1 = (a1 = 1, a2 = 2),
-           val2 = (b1 = 11, b2 = 22),
-           val3 = [111, 222],
-           val4 = 4.3,
-       );
-
-julia> flatten(data)
-(val1⁻a1 = 1, val1⁻a2 = 2, val2⁻b1 = 11, val2⁻b2 = 22, val3 = [111, 222], val4 = 4.3)
-```
-"""
-const DEFAULT_FLATTEN_DELIM = :⁻
-
-"""
-    DEFAULT_PROD_DELIM
-
-`:ᵡ` (or `\\^x`)
-
-Separates the parent symbols from an n-dimensional array that was flattened / reshaped.
-A less common symbol was used to avoid collisions with `:_` in the parent symbols.
-
-# Example
-```jldoctest
-julia> using AxisKeys, Dates; using AxisSets: flatten
-
-julia> A = KeyedArray(
-           reshape(1:24, (4, 3, 2));
-           time=DateTime(2021, 1, 1, 11):Hour(1):DateTime(2021, 1, 1, 14),
-           obj=[:a, :b, :c],
-           loc=[1, 2],
-       );
-
-julia> axiskeys(flatten(A, (:obj, :loc)), :objᵡloc)
-6-element Vector{Symbol}:
- :aᵡ1
- :bᵡ1
- :cᵡ1
- :aᵡ2
- :bᵡ2
- :cᵡ2
-```
-"""
-const DEFAULT_PROD_DELIM = :ᵡ
-
 # There's a few places calling `only` is convenient, even for older Julia releases
 if VERSION < v"1.4"
     function _only(x)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -55,13 +55,7 @@ end
 function KeyedDataset(pairs::Pair...; constraints=Pattern[])
     # Convert any non-tuple keys to tuples
     tupled_pairs = map(pairs) do (k, v)
-        k isa Tuple && return k => v
-
-        if k isa Symbol
-            Tuple(Symbol.(split(string(k), string(DEFAULT_FLATTEN_DELIM)))) => v
-        else
-            (k,) => v
-        end
+        k isa Tuple ? k => v : (k,) => v
     end
 
     data = LittleDict(tupled_pairs)

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -9,8 +9,6 @@ isassociative(x) = false
     flatten(collection, [delim])
 
 Flatten a collection of nested associative types into a flat collection of pairs.
-If the input keys are symbols (ie: `NamedTuple`) then the $DEFAULT_FLATTEN_DELIM  will be
-used, otherwise `Tuple` keys will be returned.
 
 # Example
 ```jldoctest
@@ -23,8 +21,8 @@ julia> data = (
            val4 = 4.3,
        );
 
-julia> flatten(data)
-(val1⁻a1 = 1, val1⁻a2 = 2, val2⁻b1 = 11, val2⁻b2 = 22, val3 = [111, 222], val4 = 4.3)
+julia> flatten(data, :_)
+(val1_a1 = 1, val1_a2 = 2, val2_b1 = 11, val2_b2 = 22, val3 = [111, 222], val4 = 4.3)
 ```
 
     flatten(A, dims, [delim])
@@ -32,8 +30,6 @@ julia> flatten(data)
 Flatten a `KeyedArray` along the specified consecutive dimensions.
 The `dims` argument can either be a `Tuple` of symbols or a `Pair{Tuple, Symbol}` if
 you'd like to specify the desired flattened dimension name.
-If the `dims` is just a `Tuple` with no output dimension specified then $DEFAULT_PROD_DELIM
-will be used to generate the new dimension name.
 
 # Example
 ```jldoctest
@@ -46,8 +42,8 @@ julia> A = KeyedArray(
            loc=[1, 2],
        );
 
-julia> dimnames(flatten(A, (:obj, :loc)))
-(:time, :objᵡloc)
+julia> dimnames(flatten(A, (:obj, :loc), :_))
+(:time, :obj_loc)
 ```
 """
 function flatten end
@@ -76,8 +72,9 @@ function flatten(x::Union{Vector{<:Pair}, Iterators.Pairs}, delim::Nothing)
     return collect(result)
 end
 
-# NOTE: NamedTuples only support symbol names, so we use a simple :⁻ delimiter
-function flatten(x::NamedTuple, delim::Symbol=DEFAULT_FLATTEN_DELIM)::NamedTuple
+# NOTE: NamedTuples only support symbol names, so we fallback to a pairs iterator if a delimiter isn't provided
+flatten(x::NamedTuple, delim::Nothing) = flatten(pairs(x), delim)
+function flatten(x::NamedTuple, delim::Symbol)::NamedTuple
     kwargs = map(flatten(pairs(x))) do (k, v)
         _k = isa(k, Tuple) ? join(k, delim) : k
         return Symbol(_k) => v
@@ -98,7 +95,7 @@ function flatten(x::Vector{<:Pair}, delim::Symbol)
     return [Symbol(join(k, delim)) => v for (k, v) in flatten(x)]
 end
 
-function flatten(A::KeyedArray, dims::Tuple, delim=DEFAULT_PROD_DELIM)
+function flatten(A::KeyedArray, dims::Tuple, delim::Symbol)
     new_name = Symbol(join(dims, delim))
     flatten(A, dims => new_name, delim)
 end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -64,7 +64,7 @@ function flatten(x::Union{Vector{<:Pair}, Iterators.Pairs}, delim::Nothing)
                     put!(chnl, new_key => _v)
                 end
             else
-                put!(chnl, (k,) => v)
+                put!(chnl, (k isa Tuple ? k : (k,)) => v)
             end
         end
     end

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -106,7 +106,10 @@ function Base.in(item::Tuple, pattern::Pattern)
 
             # If the next value will match then bump the pattern iterator state
             # otherwise just bump the item iterate and we'll check again next time.
-            if item_val === next_val
+            if (
+                (item_val isa Type && next_val isa Type && item_val <: next_val) ||
+                item_val == next_val
+            )
                 pat_iter = next_iter
             else
                 item_iter = iterate(item, item_st)

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -88,7 +88,7 @@
             # to construct a KeyedDatasets from an existing nested structure of KeyedArrays.
             @testset "NamedTuples" begin
                 # In this case, the resulting keys from flatten need to be symbols with
-                # an `:ᵡ` delimiter
+                # an `:_` delimiter
                 data = (
                     group1 = (
                         a = KeyedArray(
@@ -117,7 +117,7 @@
                         )
                     )
                 )
-                ds = KeyedDataset(; flatten(data)...)
+                ds = KeyedDataset(flatten(data)...)
 
                 # Test that we successfully extracted the dims
                 @test issetequal([:time, :loc, :obj, :label], dimnames(ds))
@@ -143,7 +143,8 @@
                     [(:group1, :a), (:group1, :b), (:group2, :a), (:group2, :b)], keys(ds.data)
                 )
 
-                # Test an example where we don't use the default delimiter
+                # Test an example where we pass a delimiter to flatten to a named tuple,
+                # that we can use as kwargs...
                 ds = KeyedDataset(; flatten(data, :_)...)
 
                 @test constraintmap(ds) == LittleDict(

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -92,6 +92,7 @@ using AxisSets: flatten
                 (DateTime(2021, 1, 1, 14),) => 4.3,
             )
             @test flatten(data) == expected
+            @test flatten(expected) == expected
 
             expected = Dict(
                 "2021-01-01T11:00:00_1" => "a",
@@ -103,6 +104,7 @@ using AxisSets: flatten
             )
             # Test that we can flatten that to a string
             @test flatten(data, "_") == expected
+            @test flatten(expected, "_") == expected
         end
 
         @testset "NamedTuple" begin
@@ -122,6 +124,20 @@ using AxisSets: flatten
                 val4 = 4.3,
             )
             @test flatten(data, :_) == expected
+            @test flatten(expected, :_) == expected
+
+            # By default calling `flatten` on a named tuple without a delimiter will
+            # return pairs
+            expected = [
+                (:val1, :a1) => 1,
+                (:val1, :a2) => 2,
+                (:val2, :b1) => 11,
+                (:val2, :b2) => 22,
+                (:val3,) => [111, 222],
+                (:val4,) => 4.3,
+            ]
+            @test flatten(data) == expected
+            @test flatten(expected) == expected
         end
 
         @testset "KeyedArray" begin

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -112,16 +112,16 @@ using AxisSets: flatten
                 val3 = [111, 222],
                 val4 = 4.3,
             )
-            # Expected names for NamedTuple must be symbols. Default delimiter is `:⁻`
+            # Expected names for NamedTuple must be symbols. Default delimiter is `:_`
             expected = (
-                val1⁻a1 = 1,
-                val1⁻a2 = 2,
-                val2⁻b1 = 11,
-                val2⁻b2 = 22,
+                val1_a1 = 1,
+                val1_a2 = 2,
+                val2_b1 = 11,
+                val2_b2 = 22,
                 val3 = [111, 222],
                 val4 = 4.3,
             )
-            @test flatten(data) == expected
+            @test flatten(data, :_) == expected
         end
 
         @testset "KeyedArray" begin
@@ -137,22 +137,22 @@ using AxisSets: flatten
                 expected = KeyedArray(
                     reshape(1:24, (4, 6));
                     time=dt,
-                    locᵡobj=[Symbol(join((l, o), :ᵡ)) for l in 1:3, o in [:a, :b]][:],
+                    loc_obj=[Symbol(join((l, o), :_)) for l in 1:3, o in [:a, :b]][:],
                 )
-                @test flatten(A, (:loc, :obj)) == expected
+                @test flatten(A, (:loc, :obj), :_) == expected
             end
 
             @testset "head dims" begin
                 expected = KeyedArray(
                     reshape(1:24, (12, 2));
-                    timeᵡloc=[Symbol(join((t, l), :ᵡ)) for t in dt, l in 1:3][:],
+                    time_loc=[Symbol(join((t, l), :_)) for t in dt, l in 1:3][:],
                     obj=[:a, :b],
                 )
-                @test flatten(A, (:time, :loc)) == expected
+                @test flatten(A, (:time, :loc), :_) == expected
             end
 
-            @test_throws ArgumentError flatten(A, (:time,))
-            @test_throws ArgumentError flatten(A, (:time, :obj))
+            @test_throws ArgumentError flatten(A, (:time,), :_)
+            @test_throws ArgumentError flatten(A, (:time, :obj), :_)
         end
 
         # TODO: Support group flatten operations


### PR DESCRIPTION
Rather than having a bunch of delimiters with specific meanings it seems like maybe we should just require a `delim` argument if folks want to combine names for dimensions or named tuples. Otherwise, I think falling back to use `Tuple`s whenever possible is the least destructive/opinionated behaviour. This is technically breaking, since it changes the default behaviour when calling `flatten` on a `NamedTuple`... though we also never exported this function.

Closes #5 