### PR TITLE
Handle singleton pair arguments to `flatten`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -1,6 +1,7 @@
 
 isassociative(x::NamedTuple) = true
 isassociative(x::AbstractDict) = true
+isassociative(x::Pair) = true
 isassociative(x::Iterators.Pairs) = true
 isassociative(x::Vector{<:Pair}) = true
 isassociative(x) = false
@@ -51,6 +52,10 @@ function flatten end
 # Single arg version defaults to `nothing` delim
 # All other methods dispatch on the two arg form to be explicit
 flatten(x) = flatten(x, nothing)
+
+# For simplicity we just convert singleton `Pair` arguments to `Pair[x]`, even though it's
+# less efficient.
+flatten(x::Pair, delim::Nothing) = flatten([x], delim)
 
 # Primary flatten algorithm. Other methods should call this and adjust keys as necessary.
 function flatten(x::Union{Vector{<:Pair}, Iterators.Pairs}, delim::Nothing)

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -56,6 +56,9 @@ using AxisSets: flatten
                 "val4" => 4.3,
             ]
             @test flatten(data, "_") == delimited
+
+            # Test a nested singleton pair
+            @test flatten("val1" => "a1" => 1) == [("val1", "a1") => 1]
         end
 
         @testset "Dict" begin


### PR DESCRIPTION
Pretty simple non-breaking change to support make `flatten("foo" => "bar" => 2)` consistent with `flatten(["foo" => (bar = 2;)])`.