### PR TITLE
Update OrderedCollections version to pull in bugfix for merge

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
@@ -18,7 +18,7 @@ AxisKeys = "0.1.16"
 FeatureTransforms = "0.3.6"
 Impute = "0.6"
 NamedDims = "0.2"
-OrderedCollections = "1"
+OrderedCollections = "1.4.1"
 ReadOnlyArrays = "0.1"
 julia = "1.5"
 

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -111,6 +111,19 @@ end
         )
         ds = merge(ds1, ds2)
         @test issetequal(keys(ds.data), [(:val1,), (:val2,)])
+
+        # Make sure merge works on >2 datasets
+        ds3 = KeyedDataset(
+            :val3 => KeyedArray(
+                rand(4, 3, 2) .+ 2.0;
+                time=DateTime(2021, 1, 1, 11):Hour(1):DateTime(2021, 1, 1, 14),
+                loc=1:3,
+                obj=[:a, :b],
+            )
+        )
+
+        ds = merge(ds1, ds2, ds3)
+        @test issetequal(keys(ds.data), [(:val1,), (:val2,), (:val3,)])
     end
     @testset "replace" begin
         ds1 = KeyedDataset(


### PR DESCRIPTION
Closes https://github.com/invenia/AxisSets.jl/issues/56.

This simply updates version requirement of OrderedCollections to use the changes from https://github.com/JuliaCollections/OrderedCollections.jl/pull/79 to prevent failures when using `merge` on more than 2 datasets.