### PR TITLE
Fix docs using julia 1.7.1

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -169,7 +169,7 @@ julia> ds = KeyedDataset(
 
 julia> collect(constraintmap(ds))
 3-element Vector{Pair{AxisSets.Pattern, Set{Tuple}}}:
- Pattern((:__, :time)) => Set([(:val2, :time), (:val1, :time)])
+ Pattern((:__, :time)) => Set([(:val1, :time), (:val2, :time)])
   Pattern((:__, :loc)) => Set([(:val1, :loc), (:val2, :loc)])
   Pattern((:__, :obj)) => Set([(:val2, :obj), (:val1, :obj)])
 ```

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -119,9 +119,9 @@ julia> [k => parent(parent(v)) for (k, v) in Impute.filter(ds; dims=Pattern(:tra
 julia> [k => parent(parent(v)) for (k, v) in Impute.filter(ds; dims=:loc).data]
 4-element Vector{Pair{Tuple{Symbol, Symbol}, Matrix{Union{Missing, Float64}}}}:
    (:train, :temp) => [1.0 1.1; missing 2.2; 3.0 3.3]
-   (:train, :load) => [7.0; 8.0; 9.0]
+   (:train, :load) => [7.0; 8.0; 9.0;;]
  (:predict, :temp) => [1.0 missing; 2.0 2.2; 3.0 3.3]
- (:predict, :load) => [7.0; 8.1; 9.0]
+ (:predict, :load) => [7.0; 8.1; 9.0;;]
 ```
 """
 Impute.apply(ds::KeyedDataset, f::Filter; dims) = Impute.apply!(deepcopy(ds), f; dims=dims)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -106,13 +106,25 @@ julia> ds[:b] = KeyedArray(ones(3, 2); time=1:3, lag=[-1, -2]);
 
 julia> collect(constraintmap(ds))
 2-element Vector{Pair{AxisSets.Pattern, Set{Tuple}}}:
- Pattern((:__, :time)) => Set([(:b, :time), (:a, :time)])
+ Pattern((:__, :time)) => Set([(:a, :time), (:b, :time)])
   Pattern((:__, :lag)) => Set([(:b, :lag)])
 
 julia> ds[:c] = KeyedArray(ones(3, 2); time=2:4, lag=[-1, -2])
 ERROR: KeyAlignmentError: Misaligned dimension keys on constraint Pattern((:__, :time))
-  Tuple[(:b, :time), (:a, :time)] ∈ 3-element UnitRange{Int64}
+  Tuple[(:a, :time), (:b, :time)] ∈ 3-element UnitRange{Int64}
   Tuple[(:c, :time)] ∈ 3-element UnitRange{Int64}
+
+Stacktrace:
+ [1] validate(ds::KeyedDataset, constraint::AxisSets.Pattern{Tuple{Symbol, Symbol}}, paths::Set{Tuple})
+   @ AxisSets ~/src/invenia/AxisSets.jl/src/dataset.jl:293
+ [2] validate(ds::KeyedDataset)
+   @ AxisSets ~/src/invenia/AxisSets.jl/src/dataset.jl:267
+ [3] setindex!(ds::KeyedDataset, val::KeyedArray{Float64, 2, NamedDimsArray{(:time, :lag), Float64, 2, Matrix{Float64}}, Tuple{UnitRange{Int64}, Vector{Int64}}}, key::Tuple{Symbol})
+   @ AxisSets ~/src/invenia/AxisSets.jl/src/indexing.jl:132
+ [4] setindex!(ds::KeyedDataset, val::KeyedArray{Float64, 2, NamedDimsArray{(:time, :lag), Float64, 2, Matrix{Float64}}, Tuple{UnitRange{Int64}, Vector{Int64}}}, key::Symbol)
+   @ AxisSets ~/src/invenia/AxisSets.jl/src/indexing.jl:118
+ [5] top-level scope
+   @ none:1
 ```
 """
 Base.setindex!(ds::KeyedDataset, val, key::Symbol) = setindex!(ds, val, (key,))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -97,7 +97,7 @@ If the axis values of the new `val` doesn't meet the existing constraints in the
 then an error will be thrown.
 
 # Example
-```jldoctest
+```jldoctest; filter = r"(?s)Stacktrace.*"
 julia> using AxisKeys; using AxisSets: KeyedDataset, constraintmap;
 
 julia> ds = KeyedDataset(:a => KeyedArray(zeros(3); time=1:3));
@@ -113,18 +113,6 @@ julia> ds[:c] = KeyedArray(ones(3, 2); time=2:4, lag=[-1, -2])
 ERROR: KeyAlignmentError: Misaligned dimension keys on constraint Pattern((:__, :time))
   Tuple[(:a, :time), (:b, :time)] ∈ 3-element UnitRange{Int64}
   Tuple[(:c, :time)] ∈ 3-element UnitRange{Int64}
-
-Stacktrace:
- [1] validate(ds::KeyedDataset, constraint::AxisSets.Pattern{Tuple{Symbol, Symbol}}, paths::Set{Tuple})
-   @ AxisSets ~/src/invenia/AxisSets.jl/src/dataset.jl:293
- [2] validate(ds::KeyedDataset)
-   @ AxisSets ~/src/invenia/AxisSets.jl/src/dataset.jl:267
- [3] setindex!(ds::KeyedDataset, val::KeyedArray{Float64, 2, NamedDimsArray{(:time, :lag), Float64, 2, Matrix{Float64}}, Tuple{UnitRange{Int64}, Vector{Int64}}}, key::Tuple{Symbol})
-   @ AxisSets ~/src/invenia/AxisSets.jl/src/indexing.jl:132
- [4] setindex!(ds::KeyedDataset, val::KeyedArray{Float64, 2, NamedDimsArray{(:time, :lag), Float64, 2, Matrix{Float64}}, Tuple{UnitRange{Int64}, Vector{Int64}}}, key::Symbol)
-   @ AxisSets ~/src/invenia/AxisSets.jl/src/indexing.jl:118
- [5] top-level scope
-   @ none:1
 ```
 """
 Base.setindex!(ds::KeyedDataset, val, key::Symbol) = setindex!(ds, val, (key,))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -91,10 +91,10 @@ end
 """
     setindex!(ds::KeyedDataset{T}, val, key) -> T
 
-Store the new `val` in the [`KeyedDataset`](@ref). If any new dimension names don't any
-existing constraints then `Pattern(:__, <dimname>)` is used by default.
+Store the new `val` in the [`KeyedDataset`](@ref). If any new dimension names don't 
+match any existing constraints then `Pattern(:__, <dimname>)` is used by default.
 If the axis values of the new `val` doesn't meet the existing constraints in the dataset
-then an error will be throw.
+then an error will be thrown.
 
 # Example
 ```jldoctest


### PR DESCRIPTION
Fixes #68 by regenerating the doctests outputs using Julia 1.7.1.

Alternative would be to tweak the examples so the outputs don't depend on the Julia version, but that feels needlessly complex and may hide useful output info.
