### PR TITLE
Use Julia 1.6 (LTS) for docs job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.6' # Current LTS
       - run: |
           julia --project=docs -e '
             using Pkg


### PR DESCRIPTION
Fixes #69 

Avoids having to keep up with changes to doctest outputs (following suggestion in [supplanted PR](https://github.com/invenia/AxisSets.jl/pull/69#issuecomment-1020315137)).