### PR TITLE
Use isequal rather than == in a couple conditions 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -285,7 +285,7 @@ function validate(ds::KeyedDataset, constraint::Pattern, paths)
             groups = Tuple(Vector{Tuple}() for i in 1:n)
             for p in paths
                 for i in 1:n
-                    if axiskeys(ds, p) == keys[i]
+                    if isequal(axiskeys(ds, p), keys[i])
                         push!(groups[i], p)
                     end
                 end

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -91,7 +91,7 @@ function Base.in(item::Tuple, pattern::Pattern)
         # Iterate as normal if the pattern value matches, is a subtype or it's :_
         if (
             (item_val isa Type && pat_val isa Type && item_val <: pat_val) ||
-            item_val == pat_val ||
+            isequal(item_val, pat_val) ||
             pat_val === :_
         )
             pat_iter = iterate(pattern.segments, pat_st)
@@ -108,7 +108,7 @@ function Base.in(item::Tuple, pattern::Pattern)
             # otherwise just bump the item iterate and we'll check again next time.
             if (
                 (item_val isa Type && next_val isa Type && item_val <: next_val) ||
-                item_val == next_val
+                isequal(item_val, next_val)
             )
                 pat_iter = next_iter
             else


### PR DESCRIPTION
Avoid potential non-boolean type errors on missings.