### PR TITLE
Adds conditions for some tests to pass in Julia 1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisSets"
 uuid = "a1a1544e-ba16-4f6d-8861-e833517b754e"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -112,7 +112,9 @@ function flatten(A::KeyedArray, dims::Pair{<:Tuple, Symbol}, delim=nothing)
 
     # The max difference between the dimensions to flatten should be 1, otherwise we have
     # non-consecutive dimensions and should throw an error
-    maximum(diff(fd)) == 1 || throw(ArgumentError("Flatten dimensions must be consecutive"))
+    d = diff(fd)
+    isempty(d) && throw(ArgumentError("Flatten dimensions must be consecutive"))
+    maximum(d) == 1 || throw(ArgumentError("Flatten dimensions must be consecutive"))
 
     # The offset is equal to the number of dimensions that are being dropped
     # (ie: ndims(origin) - ndims(flattened))

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -170,11 +170,7 @@ using AxisSets: flatten
                 @test flatten(A, (:time, :loc), :_) == expected
             end
 
-            if VERSION < v"1.8"
-                @test_throws ArgumentError flatten(A, (:time,), :_)
-            else
-                @test_throws MethodError flatten(A, (:time,), :_)
-            end
+            @test_throws ArgumentError flatten(A, (:time,), :_)
             @test_throws ArgumentError flatten(A, (:time, :obj), :_)
         end
 

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -170,7 +170,11 @@ using AxisSets: flatten
                 @test flatten(A, (:time, :loc), :_) == expected
             end
 
-            @test_throws ArgumentError flatten(A, (:time,), :_)
+            if VERSION < v"1.8"
+                @test_throws ArgumentError flatten(A, (:time,), :_)
+            else
+                @test_throws MethodError flatten(A, (:time,), :_)
+            end
             @test_throws ArgumentError flatten(A, (:time, :obj), :_)
         end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -27,8 +27,13 @@
         @test isa(ds.time, ReadOnlyArray)
         @test isa(ds.val1.time, ReadOnlyArray)
 
-        @test_throws ErrorException ds.time[3] = DateTime(2020, 1, 1)
-        @test_throws ErrorException ds.val1.time[3] = DateTime(2020, 1, 1)
+        if VERSION < v"1.8"
+            @test_throws ErrorException ds.time[3] = DateTime(2020, 1, 1)
+            @test_throws ErrorException ds.val1.time[3] = DateTime(2020, 1, 1)
+        else
+            @test_throws CanonicalIndexError ds.time[3] = DateTime(2020, 1, 1)
+            @test_throws CanonicalIndexError ds.val1.time[3] = DateTime(2020, 1, 1)
+        end
 
         # Test that we can still modify non-shared keys
         ds.val1.obj[2] = :d


### PR DESCRIPTION
Fixes #78 

This is just a workaround for fixing some of tests such that they pass. Different `Errors` are thrown between the different `Julia` versions, so I thought just adding a condition around that would be fine.

Let me know if I have to change anything else :)